### PR TITLE
Improve blackjack UI with betting

### DIFF
--- a/blackjack/index.html
+++ b/blackjack/index.html
@@ -7,21 +7,29 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
 </head>
-<body class="bg-gray-900 text-gray-100 min-h-screen flex items-center justify-center p-4">
+<body class="bg-gray-900 text-gray-100 min-h-screen flex items-center justify-center p-4 relative">
+    <div id="balance-container" class="absolute top-4 right-4 text-xl font-semibold">Balance: $<span id="balance-amount"></span></div>
     <div class="max-w-lg w-full">
         <h1 class="text-3xl font-bold text-center mb-4">Blackjack</h1>
         <div class="bg-gray-800 p-4 rounded-lg shadow-lg space-y-4">
             <div id="dealer" class="space-y-2">
                 <h2 class="text-xl font-semibold">Dealer <span id="dealer-score"></span></h2>
-                <div id="dealer-cards" class="flex space-x-2"></div>
+                <div id="dealer-cards" class="flex space-x-4"></div>
             </div>
             <div id="player" class="space-y-2">
                 <h2 class="text-xl font-semibold">Player <span id="player-score"></span></h2>
-                <div id="player-cards" class="flex space-x-2"></div>
+                <div id="player-cards" class="flex space-x-4"></div>
             </div>
             <div id="message" class="text-center text-lg font-semibold h-6"></div>
+            <div class="flex justify-center items-center space-x-2">
+                <button id="bet-dec" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">-5</button>
+                <input id="bet" type="number" min="0" class="bg-gray-700 text-white w-24 text-center rounded p-1" value="0">
+                <button id="bet-inc" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">+5</button>
+            </div>
+            <div class="flex justify-center">
+                <button id="deal" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition mt-2">Deal</button>
+            </div>
             <div class="flex justify-center space-x-4">
-                <button id="deal" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition">Deal</button>
                 <button id="hit" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded transition" disabled>Hit</button>
                 <button id="stand" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded transition" disabled>Stand</button>
             </div>


### PR DESCRIPTION
## Summary
- add persistent balance display stored in localStorage
- allow choosing bet with -5/+5 controls and input
- require valid bet before dealing and update balance based on result
- improve card layout and color for a deck-like feel

## Testing
- `node -e "require('./blackjack/script.js');"`

------
https://chatgpt.com/codex/tasks/task_e_68797cb923908329a4da2a6795dbafb1